### PR TITLE
Enforce Servers cipher order

### DIFF
--- a/c_src/p1_tls_drv.c
+++ b/c_src/p1_tls_drv.c
@@ -462,6 +462,7 @@ static ErlDrvSSizeT tls_drv_control(ErlDrvData handle,
 	    if (strlen(ciphers) == 0)
 	       ciphers = CIPHERS;
 	    SSL_CTX_set_cipher_list(ctx, ciphers);
+	    SSL_CTX_set_options(ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
 
 #ifndef OPENSSL_NO_ECDH
 	    if (command == SET_CERTIFICATE_FILE_ACCEPT) {


### PR DESCRIPTION
As discussed in processone/ejabberd#142, a check has shown that clients use terrible cipher lists. This patch makes the server enforce its cipher order when performing an SSL handshake. Assuming a sane cipher order in the server config, this should be more secure.
