### PR TITLE
Always set (EC)DH parameters

### DIFF
--- a/c_src/p1_tls_drv.c
+++ b/c_src/p1_tls_drv.c
@@ -499,14 +499,10 @@ static ErlDrvSSizeT tls_drv_control(ErlDrvData handle,
 	    SSL_CTX_set_cipher_list(ctx, ciphers);
 
 #ifndef OPENSSL_NO_ECDH
-	    if (command == SET_CERTIFICATE_FILE_ACCEPT) {
-		setup_ecdh(ctx);
-	    }
+	    setup_ecdh(ctx);
 #endif
 #ifndef OPENSSL_NO_DH
-	    if (command == SET_CERTIFICATE_FILE_ACCEPT) {
-		setup_dh(ctx);
-	    }
+	    setup_dh(ctx);
 #endif
 
 	    SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_OFF);


### PR DESCRIPTION
Don't skip setting (EC)DH parameters when the first connection after starting the server happens to be outgoing, because the OpenSSL context will later be reused when accepting incoming connections.  This makes sure that ephemeral (EC)DH cipher suites can be offered either way.

Thanks go to Sam Whited for reporting the problem and for his help with tracking the issue down.
