### PR TITLE
Add support for reading DH parameters from a file

### DIFF
--- a/c_src/p1_tls_drv.c
+++ b/c_src/p1_tls_drv.c
@@ -537,7 +537,10 @@ static ErlDrvSSizeT tls_drv_control(ErlDrvData handle,
 	 size_t protocol_options_len = strlen(protocol_options);
 	 char *dh_file = protocol_options + protocol_options_len + 1;
 	 size_t dh_file_len = strlen(dh_file);
-	 char *hash_key = (char *)driver_alloc(key_file_len + ciphers_len + 1);
+	 char *hash_key = (char *)driver_alloc(key_file_len +
+					       ciphers_len +
+					       protocol_options_len +
+					       dh_file_len + 1);
 	 long options = 0L;
 
 	 if (protocol_options_len != 0) {
@@ -553,7 +556,8 @@ static ErlDrvSSizeT tls_drv_control(ErlDrvData handle,
 	    free(popts);
 	 }
 
-	 sprintf(hash_key, "%s%s", key_file, ciphers);
+	 sprintf(hash_key, "%s%s%s%s", key_file, ciphers, protocol_options,
+		 dh_file);
 	 SSL_CTX *ssl_ctx = hash_table_lookup(hash_key, &key_mtime, &dh_mtime);
 
 	 if (dh_file_len == 0)

--- a/src/p1_tls.erl
+++ b/src/p1_tls.erl
@@ -139,10 +139,17 @@ tcp_to_tls(TCPSocket, Options) ->
                                  false ->
                                      <<>>
                              end,
+          DHFile = case lists:keysearch(dhfile, 1, Options) of
+                       {value, {dhfile, D}} ->
+                           iolist_to_binary(D);
+                       false ->
+                           <<>>
+                   end,
           CertFile1 = iolist_to_binary(CertFile),
 	  case catch port_control(Port, Command bor Flags,
 				  <<CertFile1/binary, 0, Ciphers/binary,
-				    0, ProtocolOpts/binary, 0>>)
+				    0, ProtocolOpts/binary, 0, DHFile/binary,
+				    0>>)
 	      of
 	    {'EXIT', {badarg, _}} -> {error, einval};
 	    <<0>> ->


### PR DESCRIPTION
Allow for specifying a file that contains custom parameters for Diffie-Hellman key exchange.  Admins can create such a file with the command `openssl dhparam -out dh.pem 2048`, for example.

There's a [ticket asking for this feature][1], and I guess more users will be interested given the [recently published issue with using common DH parameters][2].

[1]: https://support.process-one.net/browse/EJAB-1697
[2]: https://weakdh.org/