### PR TITLE
make it less verbose for p1_tls_app:start

### DIFF
--- a/src/p1_tls_app.erl
+++ b/src/p1_tls_app.erl
@@ -52,27 +52,10 @@
 %% @end
 %%--------------------------------------------------------------------
 start(_StartType, _StartArgs) ->
-    Res = case application:start(crypto) of
-              ok -> ok;
-              {error, {already_started, _}} -> ok;
-              Err -> Err
-          end,
-    case Res of
-        ok ->
-            case p1_sha:load_nif() of
-                ok ->
-                    case p1_tls_sup:start_link() of
-                        {ok, Pid} ->
-                            {ok, Pid};
-                        Error ->
-                            Error
-                    end;
-                Error ->
-                    Error
-            end;
-        Error ->
-            Error
-    end.
+    ok =  application:ensure_started(crypto),
+    ok =  p1_sha:load_nif(),
+    p1_tls_sup:start_link().
+
 
 %%--------------------------------------------------------------------
 %% @private


### PR DESCRIPTION
I've heard of "defensive programming" vs "let it crash", so I think the following changes follow the rule of "let it crash".